### PR TITLE
cfg file enhancements and shutdown/poweroff command.

### DIFF
--- a/blink.cfg
+++ b/blink.cfg
@@ -15,6 +15,7 @@ MON_BATTERY=7        # When battery percentage is below this, shut down.
 #WARN_BATTERY_GPIO=XIO_P5  # When battery warning, activate this GPIO.
 #WARN_BATTERY_GPIO_VALUE=0 # Warning value to write to WARN_BATTERY_GPIO.
 
+HAVE_TEMP_SENSOR=0    # Set to 1 if your board has a battery temperature sensor
 #MON_TEMPERATURE=800  # Shutdown temperature in tenths of a degree C.
 #WARN_TEMPERATURE=750 # Warning temperature in tenths of a degree C.
 #WARN_TEMPERATURE_GPIO=XIO_P6  # When temperature warning, activate this GPIO.

--- a/blink.cfg
+++ b/blink.cfg
@@ -6,11 +6,11 @@
 BLINK_STATUS=1       # Blink CHIP's status LED.
 #BLINK_GPIO=XIO_P7    # Blink a GPIO.
 
-MON_RESET=1          # Monitor reset button for short press.
+#MON_RESET=1          # Monitor reset button for short press.
 #MON_GPIO=XIO_P4      # Shutdown when this GPIO is triggered.
 #MON_GPIO_VALUE=0     # The value read from MON_GPIO that initiates shutdown.
 
-#MON_BATTERY=7        # When battery percentage is below this, shut down.
+MON_BATTERY=7        # When battery percentage is below this, shut down.
 #WARN_BATTERY=9       # When battery percentage is below this, assert warning.
 #WARN_BATTERY_GPIO=XIO_P5  # When battery warning, activate this GPIO.
 #WARN_BATTERY_GPIO_VALUE=0 # Warning value to write to WARN_BATTERY_GPIO.
@@ -19,3 +19,5 @@ MON_RESET=1          # Monitor reset button for short press.
 #WARN_TEMPERATURE=750 # Warning temperature in tenths of a degree C.
 #WARN_TEMPERATURE_GPIO=XIO_P6  # When temperature warning, activate this GPIO.
 #WARN_TEMPERATURE_GPIO_VALUE=0 # Warning value to write to WARN_TEMPERATURE_GPIO.
+
+SHUTDOWN_SCRIPT=/usr/local/bin/low_battery_shutdown

--- a/blink.sh
+++ b/blink.sh
@@ -69,6 +69,7 @@ read_config()
   WARN_BATTERY_GPIO=
   WARN_BATTERY_GPIO_VALUE=0
 
+  HAVE_TEMP_SENSOR=
   MON_TEMPERATURE=
   WARN_TEMPERATURE=
   WARN_TEMPERATURE_GPIO=
@@ -211,8 +212,9 @@ init_mon_battery()
       gpio_output $WARN_BATTERY_GPIO $WARN_BATTERY_GPIO_LEVEL
     fi
 
+    TS=$(expr 2 + $HAVE_TEMP_SENSOR)
     # force ADC enable for battery voltage and current
-    i2cset -y -f 0 0x34 0x82 0xC3
+    i2cset -y -f 0 0x34 0x82 0xC$TS
 
     MON_BATTERY_SAMPLE_PWR=
     MON_BATTERY_SAMPLE_PERC=

--- a/blink.sh
+++ b/blink.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # blink.sh -- version: "17-Sep-2016"
 # Normally installed as a service started at bootup.
 # See https://github.com/fordsfords/blink/tree/gh-pages
@@ -82,8 +82,10 @@ read_config()
   WARN_BATTERY_GPIO_SET=
   WARN_TEMPERATURE_GPIO_SET=
 
-  if [ -f /usr/local/etc/blink.cfg ]; then :
-    source /usr/local/etc/blink.cfg
+  [ $# -eq 1 ] && CFG=$1 || CFG=/usr/local/etc/blink.cfg
+
+  if [ -f $CFG ]; then :
+    source $CFG
   else :
     MON_RESET=1
     BLINK_STATUS=1
@@ -470,7 +472,7 @@ if [ -f /usr/local/bin/gpio.sh ]; then :
   source /usr/local/bin/gpio.sh
 fi
 
-read_config
+read_config $1
 
 init_externals  # external I/O ports
 

--- a/blink.sh
+++ b/blink.sh
@@ -439,7 +439,8 @@ shutdown_now()
 
   [ ! -z "$SHUTDOWN_SCRIPT" ] && [ -x "$SHUTDOWN_SCRIPT" ] && $SHUTDOWN_SCRIPT '$1'
   echo "Shutdown, reason='$1'"
-  shutdown -h now
+  which shutdown && shutdown -h now
+  which poweroff && poweroff
 }
 
 

--- a/blink.sh
+++ b/blink.sh
@@ -82,6 +82,8 @@ read_config()
   WARN_BATTERY_GPIO_SET=
   WARN_TEMPERATURE_GPIO_SET=
 
+  SHUTDOWN_SCRIPT=
+
   [ $# -eq 1 ] && CFG=$1 || CFG=/usr/local/etc/blink.cfg
 
   if [ -f $CFG ]; then :
@@ -434,6 +436,8 @@ check_warn()
 
 shutdown_now()
 {
+
+  [ ! -z "$SHUTDOWN_SCRIPT" ] && [ -x "$SHUTDOWN_SCRIPT" ] && $SHUTDOWN_SCRIPT '$1'
   echo "Shutdown, reason='$1'"
   shutdown -h now
 }


### PR DESCRIPTION
- first argument is optional path to blink.cfg
- SHUTDOWN_SCRIPT option for blink.cfg
- flexible shutdown/poweroff command.

Sorry, you may not want the entire 'blink.cfg' diff.  Just the last patch.  I should have split them.